### PR TITLE
Update to allow dynamic scalling of game space:

### DIFF
--- a/GameOfLife.h
+++ b/GameOfLife.h
@@ -23,6 +23,14 @@ private:
     int32_t m_WindowHalfWidth;
     int32_t m_WindowHalfHeight;
 
+    float m_GameAspect;
+
+    /* 
+    * The game aspect ratios divided by the window aspect ratio. Used to multiply the width and height
+    * for the game quad, and bound checking for user input.
+    */
+    glm::vec2 m_GameAspectRatioMultipliers;
+
     Utils::OrthographicCameraController camera = Utils::OrthographicCameraController(400.0f);
 
     bool m_IsPaused = false;

--- a/OrthographicCameraController.cpp
+++ b/OrthographicCameraController.cpp
@@ -4,8 +4,8 @@
 #include "KeyCodes.h"
 #include "MouseCodes.h"
 
-Utils::OrthographicCameraController::OrthographicCameraController(float aspectRatio)
-	:m_AspectRatio(aspectRatio), m_Camera(-m_AspectRatio * m_Zoom, m_AspectRatio* m_Zoom, -m_AspectRatio * m_Zoom, m_AspectRatio* m_Zoom)
+Utils::OrthographicCameraController::OrthographicCameraController(float orthoX, float orthoY)
+	:m_OrthoX(orthoX), m_OrthoY(orthoY), m_Camera(-orthoX * m_Zoom, orthoX* m_Zoom, -orthoY * m_Zoom, orthoY* m_Zoom)
 {
 }
 
@@ -47,7 +47,7 @@ void Utils::OrthographicCameraController::Update(float deltaTime)
 	{
 		m_Zoom -= Input::Get().GetMouseScroll() * 0.1;
 		m_Zoom = std::max(m_Zoom, m_MaxZoom);
-		m_Camera.SetProjection(-m_AspectRatio * m_Zoom, m_AspectRatio * m_Zoom, -m_AspectRatio * m_Zoom, m_AspectRatio * m_Zoom);
+		m_Camera.SetProjection(-m_OrthoX * m_Zoom, m_OrthoX * m_Zoom, -m_OrthoY * m_Zoom, m_OrthoY * m_Zoom);
 	}
 
 	if (Input::Get().IsKeyPressed(KC_KEY_R))
@@ -55,7 +55,7 @@ void Utils::OrthographicCameraController::Update(float deltaTime)
 		m_CameraPosition.x = 0.0f;
 		m_CameraPosition.y = 0.0f;
 		m_Zoom = 1;
-		m_Camera.SetProjection(-m_AspectRatio * m_Zoom, m_AspectRatio * m_Zoom, -m_AspectRatio * m_Zoom, m_AspectRatio * m_Zoom);
+		m_Camera.SetProjection(-m_OrthoX * m_Zoom, m_OrthoX * m_Zoom, -m_OrthoY * m_Zoom, m_OrthoY * m_Zoom);
 	}
 
 	m_Camera.SetPosition(m_CameraPosition);
@@ -65,7 +65,7 @@ void Utils::OrthographicCameraController::Update(float deltaTime)
 glm::vec2 Utils::OrthographicCameraController::ScreenToWorldSpace(glm::vec2 screenPoint)
 {
 	return glm::vec2(
-		((screenPoint.x - m_AspectRatio)) * m_Zoom + m_Camera.GetPosition().x,
-		((-screenPoint.y + m_AspectRatio)) * m_Zoom + m_Camera.GetPosition().y
+		((screenPoint.x - m_OrthoX)) * m_Zoom + m_Camera.GetPosition().x,
+		((-screenPoint.y + m_OrthoY)) * m_Zoom + m_Camera.GetPosition().y
 	);
 }

--- a/OrthographicCameraController.h
+++ b/OrthographicCameraController.h
@@ -6,7 +6,7 @@ namespace Utils {
 class OrthographicCameraController
 {
 public:
-	OrthographicCameraController(float aspectRatio = 1.0f);
+	OrthographicCameraController(float orthoX = 1.0f, float orthoY = 1.0f);
 
 	void Update(float deltaTime);
 
@@ -22,7 +22,8 @@ public:
 
 private:
 
-	float m_AspectRatio;
+	float m_OrthoX;
+	float m_OrthoY;
 	float m_Zoom = 1.0f;
 	float m_MaxZoom = 0.2f;
 


### PR DESCRIPTION
- ortho camera now take height/width literals over aspect ratio, temp fix as ortho world space needs to match pixel space (can send multiplier with aspect ratio later)
- the Game quad now scales relative to it's aspect ratio to the window's aspect ratio, preventing stretch/squah of the board with non aligning aspects.